### PR TITLE
クライアント初期化時にapi-client-goのオプションをサポート. fix #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ func main() {
 
 [example_test.go](./example_test.go) も参照。
 
+### クライアントに設定を渡す
+
+`api-client-go` にある `ClientParams` オプションを `WithXXX` で指定可能です。
+
+```
+// API keysをコードから指定する例
+import (
+	// ...
+
+	client "github.com/sacloud/api-client-go"
+	sm "github.com/sacloud/secretmanager-api-go"
+)
+
+func main() {
+	client, err := sm.NewClient(client.WithApiKeys("your-token", "your-token-secret"))
+	// ...
+}
+```
+
 :warning:  v1.0に達するまでは互換性のない形で変更される可能性がありますのでご注意ください。
 
 ## ogenによるコード生成

--- a/client.go
+++ b/client.go
@@ -26,8 +26,6 @@ import (
 // DefaultAPIRootURL デフォルトのAPIルートURL
 const DefaultAPIRootURL = "https://secure.sakura.ad.jp/cloud/zone/tk1a/api/cloud/1.1"
 
-// const DefaultAPIRootURL = "https://secure.sakura.ad.jp/cloud-test/zone/is1y/api/cloud/1.1"
-
 // UserAgent APIリクエスト時のユーザーエージェント
 var UserAgent = fmt.Sprintf(
 	"secretmanager-api-go/%s (%s/%s; +https://github.com/sacloud/secretmanager-api-go) %s",
@@ -47,12 +45,13 @@ func (ss DummySecuritySource) BasicAuth(ctx context.Context, operationName v1.Op
 	return v1.BasicAuth{Username: ss.Username, Password: ss.Password, Roles: nil}, nil
 }
 
-func NewClient() (*v1.Client, error) {
-	return NewClientWithApiUrl(DefaultAPIRootURL)
+func NewClient(params ...client.ClientParam) (*v1.Client, error) {
+	return NewClientWithApiUrl(DefaultAPIRootURL, params...)
 }
 
-func NewClientWithApiUrl(apiUrl string) (*v1.Client, error) {
-	c, err := client.NewClient(apiUrl, client.WithUserAgent(UserAgent))
+func NewClientWithApiUrl(apiUrl string, params ...client.ClientParam) (*v1.Client, error) {
+	params = append(params, client.WithUserAgent(UserAgent))
+	c, err := client.NewClient(apiUrl, params...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #4

### このPRはどういう変更を行いますか？

コードからクライアント初期化時にapi-client-goの `ClientParams` を設定できるようにする

### ドキュメントの変更は必要ですか？

READMEに例を追加済み