### PR TITLE
Use secretmanager.Error instead of common error

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func main() {
 }
 ```
 
-[example_test.go](./example_test.go) も参照。
+[vaults_test.go](./vaults_test.go) / [secrets_test.go](./secrets_test.go) も参照。
 
 ### クライアントに設定を渡す
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,43 @@
+// Copyright 2025- The sacloud/kms-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretmanager
+
+type Error struct {
+	msg string
+	err error
+}
+
+func (e *Error) Error() string {
+	if e.msg != "" {
+		if e.err != nil {
+			return "secretmanager: " + e.msg + ": " + e.err.Error()
+		} else {
+			return "secretmanager: " + e.msg
+		}
+	} else {
+		return "secretmanager: " + e.err.Error()
+	}
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+func NewError(msg string, err error) *Error {
+	if err == nil {
+		return &Error{msg: msg}
+	}
+	return &Error{msg: msg, err: err}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,55 @@
+package secretmanager
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "with msg and err",
+			err:  &Error{msg: "something failed", err: baseErr},
+			want: "secretmanager: something failed: base error",
+		},
+		{
+			name: "with msg only",
+			err:  &Error{msg: "only msg"},
+			want: "secretmanager: only msg",
+		},
+		{
+			name: "with err only",
+			err:  &Error{err: baseErr},
+			want: "secretmanager: base error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewError("msg", baseErr)
+	if err.msg != "msg" || err.err != baseErr {
+		t.Errorf("NewError() did not set fields correctly")
+	}
+
+	err2 := NewError("msg only", nil)
+	if err2.msg != "msg only" || err2.err != nil {
+		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}

--- a/secrets.go
+++ b/secrets.go
@@ -45,7 +45,7 @@ func (op *secretOp) List(ctx context.Context) ([]v1.Secret, error) {
 	res, err := op.client.SecretmanagerVaultsSecretsList(ctx,
 		v1.SecretmanagerVaultsSecretsListParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, err
+		return nil, NewError("List", err)
 	}
 
 	return res.Secrets, nil
@@ -56,7 +56,7 @@ func (op *secretOp) Create(ctx context.Context, request v1.CreateSecret) (*v1.Se
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsCreateParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Create", err)
 	}
 
 	return &res.Secret, nil
@@ -72,14 +72,18 @@ func (op *secretOp) Unveil(ctx context.Context, request v1.Unveil) (*v1.Unveil, 
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsUnveilParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Unveil", err)
 	}
 
 	return &res.Secret, nil
 }
 
 func (op *secretOp) Delete(ctx context.Context, request v1.DeleteSecret) error {
-	return op.client.SecretmanagerVaultsSecretsDestroy(ctx, &v1.WrappedDeleteSecret{
+	err := op.client.SecretmanagerVaultsSecretsDestroy(ctx, &v1.WrappedDeleteSecret{
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsDestroyParams{VaultResourceID: op.vaultId})
+	if err != nil {
+		return NewError("Delete", err)
+	}
+	return nil
 }

--- a/vaults.go
+++ b/vaults.go
@@ -42,7 +42,7 @@ func NewVaultOp(client *v1.Client) VaultAPI {
 func (op *vaultOp) List(ctx context.Context) ([]v1.Vault, error) {
 	res, err := op.client.SecretmanagerVaultsList(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NewError("List", err)
 	}
 
 	return res.Vaults, nil
@@ -51,7 +51,7 @@ func (op *vaultOp) List(ctx context.Context) ([]v1.Vault, error) {
 func (op *vaultOp) Read(ctx context.Context, id string) (*v1.Vault, error) {
 	res, err := op.client.SecretmanagerVaultsRetrieve(ctx, v1.SecretmanagerVaultsRetrieveParams{ResourceID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Read", err)
 	}
 
 	return &res.Vault, nil
@@ -62,7 +62,7 @@ func (op *vaultOp) Create(ctx context.Context, request v1.CreateVault) (*v1.Crea
 		Vault: request,
 	})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Create", err)
 	}
 
 	return &res.Vault, nil
@@ -73,12 +73,16 @@ func (op *vaultOp) Update(ctx context.Context, id string, request v1.Vault) (*v1
 		Vault: request,
 	}, v1.SecretmanagerVaultsUpdateParams{ResourceID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Update", err)
 	}
 
 	return &res.Vault, nil
 }
 
 func (op *vaultOp) Delete(ctx context.Context, id string) error {
-	return op.client.SecretmanagerVaultsDestroy(ctx, v1.SecretmanagerVaultsDestroyParams{ResourceID: id})
+	err := op.client.SecretmanagerVaultsDestroy(ctx, v1.SecretmanagerVaultsDestroyParams{ResourceID: id})
+	if err != nil {
+		return NewError("Delete", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

単なる`error`やogenのerrorではなくsecretmanager-api-goで定義したErrorを返すようにする

### ドキュメントの変更は必要ですか？

必要なし