### PR TITLE
Use api-client-go's APIError

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,8 @@ package secretmanager
 import (
 	"errors"
 	"testing"
+
+	client "github.com/sacloud/api-client-go"
 )
 
 func TestError_Error(t *testing.T) {
@@ -51,5 +53,19 @@ func TestNewError(t *testing.T) {
 	err2 := NewError("msg only", nil)
 	if err2.msg != "msg only" || err2.err != nil {
 		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}
+
+func TestNewAPIError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewAPIError("msg", 404, baseErr)
+	if !client.IsNotFoundError(err) {
+		t.Errorf("IsNotFoundError is true for NewAPIError with 404")
+	}
+
+	err2 := NewAPIError("msg", 503, nil)
+	if client.IsNotFoundError(err2) {
+		t.Errorf("IsNotFoundError is false for NewAPIError with 503")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.1.0
 	github.com/ogen-go/ogen v1.14.0
-	github.com/sacloud/api-client-go v0.3.0
+	github.com/sacloud/api-client-go v0.3.2
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -38,6 +40,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sacloud/api-client-go v0.3.0 h1:NLA2BpZ5welAXBPxgmXSCjgn/k0ShDB0x5kmUHl7TJ4=
 github.com/sacloud/api-client-go v0.3.0/go.mod h1:v8ke3pxVQ9TCWEbMkfbLX8NMeGiPpE+uDwlgcUWfMgM=
+github.com/sacloud/api-client-go v0.3.2 h1:INbdSpQbyGN9Ai4hQ+Gbv3UQcgtRPG2tJrOmqT7HGl0=
+github.com/sacloud/api-client-go v0.3.2/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/packages-go v0.0.11 h1:hrRWLmfPM9w7GBs6xb5/ue6pEMl8t1UuDKyR/KfteHo=

--- a/secrets.go
+++ b/secrets.go
@@ -45,7 +45,7 @@ func (op *secretOp) List(ctx context.Context) ([]v1.Secret, error) {
 	res, err := op.client.SecretmanagerVaultsSecretsList(ctx,
 		v1.SecretmanagerVaultsSecretsListParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, createAPIError("List", err)
 	}
 
 	return res.Secrets, nil
@@ -56,7 +56,7 @@ func (op *secretOp) Create(ctx context.Context, request v1.CreateSecret) (*v1.Se
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsCreateParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, createAPIError("Create", err)
 	}
 
 	return &res.Secret, nil
@@ -72,7 +72,7 @@ func (op *secretOp) Unveil(ctx context.Context, request v1.Unveil) (*v1.Unveil, 
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsUnveilParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return nil, NewError("Unveil", err)
+		return nil, createAPIError("Unveil", err)
 	}
 
 	return &res.Secret, nil
@@ -83,7 +83,7 @@ func (op *secretOp) Delete(ctx context.Context, request v1.DeleteSecret) error {
 		Secret: request,
 	}, v1.SecretmanagerVaultsSecretsDestroyParams{VaultResourceID: op.vaultId})
 	if err != nil {
-		return NewError("Delete", err)
+		return createAPIError("Delete", err)
 	}
 	return nil
 }

--- a/vaults.go
+++ b/vaults.go
@@ -42,7 +42,7 @@ func NewVaultOp(client *v1.Client) VaultAPI {
 func (op *vaultOp) List(ctx context.Context) ([]v1.Vault, error) {
 	res, err := op.client.SecretmanagerVaultsList(ctx)
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, createAPIError("List", err)
 	}
 
 	return res.Vaults, nil
@@ -51,7 +51,7 @@ func (op *vaultOp) List(ctx context.Context) ([]v1.Vault, error) {
 func (op *vaultOp) Read(ctx context.Context, id string) (*v1.Vault, error) {
 	res, err := op.client.SecretmanagerVaultsRetrieve(ctx, v1.SecretmanagerVaultsRetrieveParams{ResourceID: id})
 	if err != nil {
-		return nil, NewError("Read", err)
+		return nil, createAPIError("Read", err)
 	}
 
 	return &res.Vault, nil
@@ -62,7 +62,7 @@ func (op *vaultOp) Create(ctx context.Context, request v1.CreateVault) (*v1.Crea
 		Vault: request,
 	})
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, createAPIError("Create", err)
 	}
 
 	return &res.Vault, nil
@@ -73,7 +73,7 @@ func (op *vaultOp) Update(ctx context.Context, id string, request v1.Vault) (*v1
 		Vault: request,
 	}, v1.SecretmanagerVaultsUpdateParams{ResourceID: id})
 	if err != nil {
-		return nil, NewError("Update", err)
+		return nil, createAPIError("Update", err)
 	}
 
 	return &res.Vault, nil
@@ -82,7 +82,7 @@ func (op *vaultOp) Update(ctx context.Context, id string, request v1.Vault) (*v1
 func (op *vaultOp) Delete(ctx context.Context, id string) error {
 	err := op.client.SecretmanagerVaultsDestroy(ctx, v1.SecretmanagerVaultsDestroyParams{ResourceID: id})
 	if err != nil {
-		return NewError("Delete", err)
+		return createAPIError("Delete", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

api-client-goに実装されたAPIErrorを使ってエラーを返すようにする。
丸められたエラーではなくステータスコード等も取得できるようになるので、それによって処理を分けられるようになる。
現状シークレットマネージャのOpenAPI定義にはエラーのケースがなくて型で判別できないので、ogenのエラーからステータスコードを取り出す処理を挟んでいる。

### ドキュメントの変更は必要ですか？

必要無し